### PR TITLE
Add implementations for `Rand` trait

### DIFF
--- a/src/mt19937.rs
+++ b/src/mt19937.rs
@@ -13,7 +13,7 @@ use std::default::Default;
 use std::mem;
 use std::num::Wrapping;
 
-use rand::{Rng, SeedableRng};
+use rand::{Rng, SeedableRng, Rand};
 
 const N: usize = 624;
 const M: usize = 397;
@@ -200,6 +200,13 @@ impl Default for MT19937 {
     #[inline]
     fn default() -> MT19937 {
         MT19937::new_unseeded()
+    }
+}
+
+impl Rand for MT19937 {
+    #[inline]
+    fn rand<R: Rng>(rng: &mut R) -> Self {
+        SeedableRng::from_seed(rng.gen::<u64>())
     }
 }
 

--- a/src/mt19937_64.rs
+++ b/src/mt19937_64.rs
@@ -13,7 +13,7 @@ use std::default::Default;
 use std::mem;
 use std::num::Wrapping;
 
-use rand::{Rng, SeedableRng};
+use rand::{Rng, SeedableRng, Rand};
 
 const NN: usize = 312;
 const MM: usize = 156;
@@ -188,6 +188,13 @@ impl Default for MT19937_64 {
     #[inline]
     fn default() -> MT19937_64 {
         MT19937_64::new_unseeded()
+    }
+}
+
+impl Rand for MT19937_64 {
+    #[inline]
+    fn rand<R: Rng>(rng: &mut R) -> Self {
+        SeedableRng::from_seed(rng.gen::<u64>())
     }
 }
 


### PR DESCRIPTION
The `rand` crate provides `Rand` implementations for several of its generators, which serve as a convenient way of obtaining a randomly-seeded instance of a generator ([see e.g. here](https://dcrewi.github.io/rust-mersenne-twister/doc/0.3/rand/trait.Rand.html)).  For example, this function is able to seed any such `Rng` randomly from a seed obtained from `OsRng`:

    fn from_osrng<T: Rng + Rand>() -> io::Result<T> {
        let mut osrng = try!(OsRng::new());
        Ok(osrng.gen())
    }

This pull request adds such `impl`s to this library's generators.