### PR TITLE
Add support for rand v0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.2.0
+  - 1.15.0
   - stable
   - beta
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ include = [
 ]
 
 [dependencies]
-rand = "0.3"
+rand = ">=0.3, <0.5"
 
 [badges]
 travis-ci = { repository = "dcrewi/rust-mersenne-twister" }


### PR DESCRIPTION
There were no significant breaking changes in rand 0.4, so this crate still seems to be fully compatible. On the other hand, the dependency's version range must be expanded to prevent the installation of multiple `rand` crate versions, which would lead to trait implementation conflicts.
  
Update: In addition, since `rand` seems to require 1.15 as the minimum compiler version at the moment, I took the liberty of modifying that in the Travis CI configuration file as well (otherwise it would break). Please let me know if you'd like the second commit separately.
  