### PR TITLE
Add crate installation description

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,15 @@
 //!
 //! ## Usage
 //!
+//! This crate is [on crates.io](https://crates.io/crates/mersenne_twister) 
+//! and can be used by adding `mersenne_twister` to the dependencies in your
+//! project's `Cargo.toml`.
+//!
+//! ```
+//! [dependencies]
+//! mersenne_twister = "1.1.1"
+//! ```
+//!
 //! If your application does not require a specific Mersenne Twister
 //! flavor (32-bit or 64-bit), you can use the default flavor for your
 //! target platform by using the `MersenneTwister` type

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //! and can be used by adding `mersenne_twister` to the dependencies in your
 //! project's `Cargo.toml`.
 //!
-//! ```
+//! ```toml
 //! [dependencies]
 //! mersenne_twister = "1.1.1"
 //! ```


### PR DESCRIPTION
Hey! I started using Rust only recently and it wasn't so obvious to me how to add this crate to my project (this is the first one I ever used). This PR adds installation description based on [rand documentation](https://docs.rs/rand/0.4.2/rand/#usage).

Thanks for implementing Mersenne Twister!